### PR TITLE
added git commit -am [msg]

### DIFF
--- a/assets/commands.json
+++ b/assets/commands.json
@@ -379,6 +379,14 @@
 						"de": "Die angegebene Nachricht als Commit Nachricht verwenden. Falls mehrere -m Optionen angegeben werden, werden die Werte als verschiedene Paragraphen zusammengehängt"
                     }
                 },
+		{
+                    "advanced": false,
+                    "code": "commit -am [message]",
+                    "desc": {
+                        "en": "Use the given message as the commit message. In addition, the -a flag will commit files that have been modified since the last commit. If multiple -m options are given, their values are concatenated as separate paragraphs. The -a combines git add and git commit.",
+			                        
+                    }
+                },
                 {
                     "advanced": false,
                     "code": "commit --all",


### PR DESCRIPTION
<!-- Filling out the template is required. You can keep it simple, but please describe as much as you can -->
### Description of the Change
<!-- What have you changed and why -->
The -am flag is often used with git commit in order to commit not only new files that are added with git add, but also commits files that have been modified since the last commit. Have not added language support.

### Possible Drawbacks
<!-- Possible side-effects or negative impacts of the code change -->
It may be possible that the user does not want to commit all modified files, in which case git commit -am would not be useful.